### PR TITLE
Custom page

### DIFF
--- a/action.php
+++ b/action.php
@@ -233,6 +233,7 @@ class action_plugin_translate extends DokuWiki_Action_Plugin {
         $my = $this->loadHelper('translate',true);
         $target_title = $_REQUEST['title'];
         $target_lang = $_REQUEST['to'];
+        $target_id = $_REQUEST['target_id'];
         $source_lang = $my->getPageLanguage();
 
         // Check if this is the original
@@ -295,8 +296,12 @@ class action_plugin_translate extends DokuWiki_Action_Plugin {
             return;
         }
 
+        // Use suggestion when not specified.
+        if (empty($target_id)) {
+            $target_id = $my->suggestTranslationId($target_title, $target_lang, $source_lang);
+        }
+        
         // Check if target page exists
-        $target_id = $my->suggestTranslationId($target_title, $target_lang, $source_lang);
         if (page_exists($target_id)) {
             // Error message
             //$this->_formErrors['title'] = 1;

--- a/action.php
+++ b/action.php
@@ -300,7 +300,7 @@ class action_plugin_translate extends DokuWiki_Action_Plugin {
         if (page_exists($target_id)) {
             // Error message
             //$this->_formErrors['title'] = 1;
-            msg(sprintf($this->getLang['e_pageexists'], $target_title),-1);
+            msg(sprintf($this->getLang('e_pageexists'), $target_id),-1);
             return;
         }
 

--- a/helper.php
+++ b/helper.php
@@ -373,6 +373,7 @@ class helper_plugin_translate extends DokuWiki_Plugin {
      */
     public function printActionTranslatePage() {
         global $ID, $INFO;
+        $target_id = $_REQUEST['target_id'] ?: $ID;
         $target_title = $_REQUEST['title'];
         $target_lang = $_REQUEST['to'];
 
@@ -412,6 +413,7 @@ class helper_plugin_translate extends DokuWiki_Plugin {
                                              '','',array('readonly'=>'readonly')));
                                              
         $form->addElement(form_makeTextField('title',$target_title,$this->getLang('translated_title'),'',$class));
+        $form->addElement(form_makeTextField('target_id',$target_id,$this->getLang('translated_id'),'',$class));
         $form->addElement(form_makeButton('submit','', $this->getLang('create_translation')));
         $form->printForm();
     }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -25,6 +25,8 @@ $lang['translate_to'] = 'Translate to';
  
 $lang['original_title'] = 'Original title';
 $lang['translated_title'] = 'Translated title';
+
+$lang['translated_id'] = 'Translated page name';
  
 $lang['create_translation'] = 'Create translation';
  


### PR DESCRIPTION
When creating new translation page, the form shows possibility to define new page name. (Just realized, it'd be better to fill original suggestion as default and not use it upon empty page name field.)