### PR TITLE
fix exclude_namespaces

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -141,7 +141,7 @@ class helper_plugin_translate extends DokuWiki_Plugin {
             if (!$any) return false;
         }
         $str = $this->getConf('exclude_namespaces');
-        if ($exc != '') {
+        if ($str != '') {
             $exc_nss = array_map('trim',explode(',',$str));
             foreach ($exc_nss as $ns)
                 if ($in_ns($id,$ns))


### PR DESCRIPTION
Since the condition at line 144 is never true, I assume this change represents the original intention.