### PR TITLE
use new form system, compatible with igor+

### DIFF
--- a/action.php
+++ b/action.php
@@ -31,8 +31,10 @@ class action_plugin_translate extends DokuWiki_Action_Plugin {
         $contr->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'handleDokuwikiStarted');
         $contr->register_hook('TPL_ACT_UNKNOWN', 'BEFORE', $this, 'handleTplActUnknown');
         $contr->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'handleActPreprocess');
-        $contr->register_hook('FORM_EDIT_OUTPUT', 'BEFORE', $this, 'handleHtmlEditformOutput', []); // new
-        $contr->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, 'handleHtmlEditformOutput'); // old
+        // Events for DW > 2020-07-29 "hogfather"
+        $contr->register_hook('FORM_EDIT_OUTPUT', 'BEFORE', $this, 'handleHtmlEditformOutput', []);
+        // Events for DW ≤ 2020-07-29 "hogfather"
+        $contr->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, 'handleHtmlEditformOutput');
         // TODO: When a translation is deleted, delete it from the original's list of translations.
         //$contr->register_hook('IO_WIKIPAGE_WRITE', 'BEFORE', $this, 'handlePageWrite');
         $contr->register_hook('TPL_ACT_RENDER', 'BEFORE', $this, 'handleActRender');
@@ -147,16 +149,21 @@ class action_plugin_translate extends DokuWiki_Action_Plugin {
         // Insert original page on the side
         $form = $event->data;
         if (is_a($form, \dokuwiki\Form\Form::class)) {
-            $pos = $form->findPositionByType('textarea'); // new
+            // DW > 2020-07-29 "hogfather"
+            $pos = $form->findPositionByType('textarea');
             if ($pos===false) return;
             $this->handleHtmlEditformOutputNG($form, $pos, $origtext);
         } else {
-            $pos = $form->findElementByType('wikitext'); // old
+            // DW ≤ 2020-07-29 "hogfather"
+            $pos = $form->findElementByType('wikitext');
             if ($pos===false) return;
             $this->handleHtmlEditformOutputLegacy($form, $pos, $origtext);
         }
     }
 
+    /**
+     * Add our elements to the form. DW > 2020-07-29 "hogfather"
+     */
     protected function handleHtmlEditformOutputNG($form, $pos, $origtext) {
         // Before the wikitext...
         $form->addElement(new dokuwiki\Form\TagOpenElement('div', array('id'=>'wrapper__wikitext','class'=>'hor')), $pos++);
@@ -177,6 +184,9 @@ class action_plugin_translate extends DokuWiki_Action_Plugin {
         $form->addElement(new dokuwiki\Form\TagCloseElement('div'), $pos++);
     }
 
+    /**
+     * Add our elements to the form. DW ≤ 2020-07-29 "hogfather"
+     */
     protected function handleHtmlEditformOutputLegacy($form, $pos, $origtext) {
         // Before the wikitext...
         $form->insertElement($pos++, form_makeOpenTag('div', array('id'=>'wrapper__wikitext','class'=>'hor')));

--- a/action.php
+++ b/action.php
@@ -168,22 +168,24 @@ class action_plugin_translate extends DokuWiki_Action_Plugin {
      */
     protected function handleHtmlEditformOutputNG($form, $pos, $origtext) {
         // Before the wikitext...
-        $form->addElement(new dokuwiki\Form\TagOpenElement('div', array('id'=>'wrapper__wikitext','class'=>'hor')), $pos++);
+        $form->addTagOpen('div', $pos++)->id('wrapper__wikitext')->addClass('hor');
         // After the wikitext...
         $pos++;
-        $form->addElement(new dokuwiki\Form\TagCloseElement('div'), $pos++);
-        $form->addElement(new dokuwiki\Form\TagOpenElement('div', array('id'=>'wrapper__sourcetext','class'=>'hor')), $pos++);
-        $origelem = '<textarea id="translate__sourcetext" '.
-                    //buildAttributes($attrs,true).
-                    'class="edit" readonly="readonly" cols="80" rows="10"'.
-                    'style="width:100%;"'.//  height:600px; overflow:auto
-                    '>'.NL.
-                    hsc($origtext).
-                    '</textarea>';
-        $form->addElement(new dokuwiki\Form\HTMLElement($origelem), $pos++);
-        $form->addElement(new dokuwiki\Form\TagCloseElement('div'), $pos++);
-        $form->addElement(new dokuwiki\Form\TagOpenElement('div', array('class'=>'clearer')), $pos++);
-        $form->addElement(new dokuwiki\Form\TagCloseElement('div'), $pos++);
+        $form->addTagClose('div', $pos++);
+        $form->addTagOpen('div', $pos++)->id('wrapper__sourcetext')->addClass('hor');
+
+        $attrs=Array();
+        $attrs['readonly']='readonly';
+        $attrs['cols']=80;
+        $attrs['rows']=10;
+        $attrs['style']='width:100%;';
+        $attrs['readonly']='readonly';
+        $form->addTextarea('origWikitext', '', $pos++)->attrs($attrs)->val($origtext)
+            ->id('translate__sourcetext')->addClass('edit');
+
+        $form->addTagClose('div', $pos++);
+        $form->addTagOpen('div', $pos++)->addClass('clearer');
+        $form->addTagClose('div', $pos++);
     }
 
     /**

--- a/action.php
+++ b/action.php
@@ -128,8 +128,10 @@ class action_plugin_translate extends DokuWiki_Action_Plugin {
 
 
     /**
-     * Hook for old event HTML_EDITFORM_OUTPUT an new event FORM_EDIT_OUTPUT
-     * Adds hidden form elements to the edit form.
+     * Hook for event HTML_EDITFORM_OUTPUT (DW ≤ 2020-07-29 "hogfather") and
+     * event FORM_EDIT_OUTPUT (DW > 2020-07-29 "hogfather" )
+     * Check and gather info on the untranslated page and the current form.
+     * If needed, call the method that adds our elements to the form.
      */
     public function handleHtmlEditformOutput($event, $param) {
         global $INFO, $ID;


### PR DESCRIPTION
HI,

This PR makes use of the new form and event system of the upcoming DokuWiki Igor version. The plugin will still be compatible with previous DW versions.

If you want to give it a try before you merge, visit https://aih8uw8shahshieti.bidule.https443.net/. This temporary DW will be automatically destroyed in a few weeks.

This should fix #14. 